### PR TITLE
reposition for hidden elements

### DIFF
--- a/Source/Scrollable.js
+++ b/Source/Scrollable.js
@@ -50,6 +50,9 @@ var Scrollable = new Class({
 
 			// Making the element scrollable via mousewheel
 			element.addEvents({
+				'mouseenter': function() {
+					scrollable.reposition();
+				},
 				'mouseover': function() {
 					if (this.scrollHeight > this.clientHeight) {
 						scrollable.showContainer();


### PR DESCRIPTION
if your element was first hidden, the scrollbar will fade in in a wrong place.
this, along with a little overhead that can be ignored imho, fixes it.
