### PR TITLE
Globally replace clientHeight with offsetHeight

### DIFF
--- a/Source/Scrollable.js
+++ b/Source/Scrollable.js
@@ -49,7 +49,7 @@ var Scrollable = new Class({
 			this.slider = new Slider(this.container, this.container.getElement('div'), {
 				mode: 'vertical',
 				onChange: function(step) {
-					this.element.scrollTop = ((this.element.scrollHeight - this.element.clientHeight) * (step / 100));
+					this.element.scrollTop = ((this.element.scrollHeight - this.element.offsetHeight) * (step / 100));
 				}.bind(this)
 			});
 			this.knob = this.container.getElement('div');
@@ -58,7 +58,7 @@ var Scrollable = new Class({
 
 			this.element.addEvents({
 				'mouseenter': function() {
-					if (this.scrollHeight > this.clientHeight) {
+					if (this.scrollHeight > this.offsetHeight) {
 						scrollable.showContainer();
 					}
 					scrollable.reposition();
@@ -137,7 +137,7 @@ var Scrollable = new Class({
 			}
 		}
 
-		this.slider.set(Math.round((this.element.scrollTop / (this.element.scrollHeight - this.element.clientHeight)) * 100));
+		this.slider.set(Math.round((this.element.scrollTop / (this.element.scrollHeight - this.element.offsetHeight)) * 100));
 	},
 
 	/**


### PR DESCRIPTION
Because clientHeight in contrast to offsetHeight does
contain e.g. a border; but scrollHeight definately doesnt,
you might experience a difference between scrollHeight and
clientHeight even if there's no active overflow and therefore
the scrollbars sometimes appear even not necessary.

This patch corrects usage of clientHeight to offsetHeight.
